### PR TITLE
Add JSON serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vs/
+bin/
+obj/
+packages/

--- a/MapleLib.csproj
+++ b/MapleLib.csproj
@@ -97,12 +97,16 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NAudio, Version=1.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.1.10.0\lib\net35\NAudio.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
@@ -182,10 +186,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NAudio\NAudio\NAudio.csproj">
-      <Project>{da4f02e3-0b5e-42cd-b8d9-5583fa51d66e}</Project>
-      <Name>NAudio</Name>
-    </ProjectReference>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MapleLib.csproj
+++ b/MapleLib.csproj
@@ -100,6 +100,9 @@
     <Reference Include="NAudio, Version=1.10.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NAudio.1.10.0\lib\net35\NAudio.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/MapleLib.csproj
+++ b/MapleLib.csproj
@@ -98,10 +98,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NAudio, Version=1.10.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NAudio.1.10.0\lib\net35\NAudio.dll</HintPath>
+      <HintPath>packages\NAudio.1.10.0\lib\net35\NAudio.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/MapleLib.csproj
+++ b/MapleLib.csproj
@@ -109,7 +109,6 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>

--- a/MapleLib.sln
+++ b/MapleLib.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30621.155
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapleLib", "MapleLib.csproj", "{28AAB36D-942E-4476-A000-0E9DE380F390}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Debug|x64.ActiveCfg = Debug|x64
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Debug|x64.Build.0 = Debug|x64
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Debug|x86.ActiveCfg = Debug|x86
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Debug|x86.Build.0 = Debug|x86
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Release|x64.ActiveCfg = Release|x64
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Release|x64.Build.0 = Release|x64
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Release|x86.ActiveCfg = Release|x86
+		{28AAB36D-942E-4476-A000-0E9DE380F390}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D772CA59-571D-40B6-B713-4D88EE5B90A7}
+	EndGlobalSection
+EndGlobal

--- a/WzLib/WzSerializer.cs
+++ b/WzLib/WzSerializer.cs
@@ -243,19 +243,29 @@ namespace MapleLib.WzLib.Serialization
                     byte[] pngbytes = stream.ToArray();
                     stream.Close();
                     tw.Write($"{depth}\"{XmlUtil.SanitizeText(property.Name)}\":{{" +
-                        $"\"width\":\"{property.PngProperty.Width}\", " +
+                        $"\"width\": {property.PngProperty.Width}, " +
                         $"\"height\": {property.PngProperty.Height}, " +
-                        $"\"basedata\": {Convert.ToBase64String(pngbytes)}\"" +
-                        $"}}{lineBreak}");
+                        $"\"basedata\": {Convert.ToBase64String(pngbytes)}\",");
                 }
                 else
                     tw.Write($"{depth}\"{XmlUtil.SanitizeText(property.Name)}\":{{" +
-                        $"\"width\":\"{property.PngProperty.Width}\", " +
-                        $"\"height\": {property.PngProperty.Height}" +
-                        $"}}{lineBreak}");
+                        $"\"width\": {property.PngProperty.Width}, " +
+                        $"\"height\": {property.PngProperty.Height},");
                 string newDepth = depth + indent;
-                foreach (WzImageProperty p in property.WzProperties)
-                    WritePropertyToJson(tw, newDepth, p);
+                if (property.WzProperties.Count() > 0)
+                {
+                    var last = property.WzProperties.Last();
+                    foreach (WzImageProperty p in property.WzProperties)
+                    {
+                        WritePropertyToJson(tw, newDepth, p);
+                        if (!p.Equals(last))
+                        {
+                            tw.Write($",{lineBreak}");
+                        }
+                    }
+                }
+                tw.Write($"}}{lineBreak}");
+
             }
             else if (prop is WzIntProperty)
             {
@@ -322,7 +332,7 @@ namespace MapleLib.WzLib.Serialization
             else if (prop is WzUOLProperty)
             {
                 WzUOLProperty property = (WzUOLProperty)prop;
-                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {property.Value}");
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": \"{property.Value}\"");
             }
             else if (prop is WzVectorProperty)
             {
@@ -347,7 +357,9 @@ namespace MapleLib.WzLib.Serialization
                     var last = property.WzProperties.Last();
                     foreach (WzImageProperty p in property.WzProperties)
                     {
+                        tw.Write("{");
                         WritePropertyToJson(tw, newDepth, p);
+                        tw.Write("}");
                         if (!p.Equals(last))
                         {
                             tw.Write($",{lineBreak}");
@@ -619,7 +631,7 @@ namespace MapleLib.WzLib.Serialization
             tw.Write("}}" + lineBreak);
             tw.Close();
             if (!parsed) img.UnparseImage();
-            //File.WriteAllText(path, pretty(File.ReadAllText(path)));
+            File.WriteAllText(path, pretty(File.ReadAllText(path)));
 
         }
 

--- a/WzLib/WzSerializer.cs
+++ b/WzLib/WzSerializer.cs
@@ -26,6 +26,8 @@ using System.Globalization;
 using System.Xml;
 using System.Drawing;
 using System.Threading;
+using System.CodeDom;
+using Newtonsoft.Json;
 
 namespace MapleLib.WzLib.Serialization
 {
@@ -184,6 +186,175 @@ namespace MapleLib.WzLib.Serialization
                 foreach (WzImageProperty property in property14.WzProperties)
                     WritePropertyToXML(tw, newDepth, property);
                 tw.Write(depth + "</extended>" + lineBreak);
+            }
+        }
+    }
+
+    public abstract class IWzJsonSerializer : ProgressingWzSerializer
+    {
+        protected string indent;
+        protected string lineBreak;
+        public static NumberFormatInfo formattingInfo;
+        protected bool ExportBase64Data = false;
+
+        protected static char[] amp = "&amp;".ToCharArray();
+        protected static char[] lt = "&lt;".ToCharArray();
+        protected static char[] gt = "&gt;".ToCharArray();
+        protected static char[] apos = "&apos;".ToCharArray();
+        protected static char[] quot = "&quot;".ToCharArray();
+
+        static IWzJsonSerializer()
+        {
+            formattingInfo = new NumberFormatInfo();
+            formattingInfo.NumberDecimalSeparator = ".";
+            formattingInfo.NumberGroupSeparator = ",";
+        }
+
+        public IWzJsonSerializer(int indentation, LineBreak lineBreakType)
+        {
+            switch (lineBreakType)
+            {
+                case LineBreak.None:
+                    lineBreak = "";
+                    break;
+                case LineBreak.Windows:
+                    lineBreak = "\r\n";
+                    break;
+                case LineBreak.Unix:
+                    lineBreak = "\n";
+                    break;
+            }
+            char[] indentArray = new char[indentation];
+            for (int i = 0; i < indentation; i++)
+                indentArray[i] = (char)0x20;
+            indent = new string(indentArray);
+        }
+
+        // TODO: this is not deserializable due to missing type information
+        protected void WritePropertyToJson(TextWriter tw, string depth, WzImageProperty prop)
+        {
+            if (prop is WzCanvasProperty)
+            {
+                WzCanvasProperty property = (WzCanvasProperty)prop;
+                if (ExportBase64Data)
+                {
+                    MemoryStream stream = new MemoryStream();
+                    property.PngProperty.GetPNG(false).Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+                    byte[] pngbytes = stream.ToArray();
+                    stream.Close();
+                    tw.Write($"{depth}\"{XmlUtil.SanitizeText(property.Name)}\":{{" +
+                        $"\"width\":\"{property.PngProperty.Width}\", " +
+                        $"\"height\": {property.PngProperty.Height}, " +
+                        $"\"basedata\": {Convert.ToBase64String(pngbytes)}\"" +
+                        $"}}{lineBreak}");
+                }
+                else
+                    tw.Write($"{depth}\"{XmlUtil.SanitizeText(property.Name)}\":{{" +
+                        $"\"width\":\"{property.PngProperty.Width}\", " +
+                        $"\"height\": {property.PngProperty.Height}" +
+                        $"}}{lineBreak}");
+                string newDepth = depth + indent;
+                foreach (WzImageProperty p in property.WzProperties)
+                    WritePropertyToJson(tw, newDepth, p);
+            }
+            else if (prop is WzIntProperty)
+            {
+                WzIntProperty property = (WzIntProperty)prop;
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {property.Value}");
+            }
+            else if (prop is WzDoubleProperty)
+            {
+                WzDoubleProperty property = (WzDoubleProperty)prop;
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {property.Value}");
+            }
+            else if (prop is WzNullProperty)
+            {
+                WzNullProperty property = (WzNullProperty)prop;
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": null");
+            }
+            else if (prop is WzSoundProperty)
+            {
+                WzSoundProperty property = (WzSoundProperty)prop;
+                if (ExportBase64Data)
+                    tw.Write($"{depth}\"{XmlUtil.SanitizeText(property.Name)}\":{{" +
+                        $"\"length\":\"{property.Length}\", " +
+                        $"\"basehead\": \"{Convert.ToBase64String(property.Header)}\"" +
+                        $"\"basedata\": \"{Convert.ToBase64String(property.GetBytes(false))}\"" +
+                        $"}}{lineBreak}");
+                else
+                    tw.Write($"{depth}\"{XmlUtil.SanitizeText(property.Name)}\":{{}}{lineBreak}");
+            }
+            else if (prop is WzStringProperty)
+            {
+                WzStringProperty property = (WzStringProperty)prop;
+                string str = XmlUtil.SanitizeText(property.Value);
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": \"{str}\"");
+            }
+            else if (prop is WzSubProperty)
+            {
+                WzSubProperty property = (WzSubProperty)prop;
+                tw.Write(depth + $"\"{XmlUtil.SanitizeText(property.Name)}\":{{" + lineBreak);
+                string newDepth = depth + indent;
+                if (property.WzProperties.Count() > 0)
+                {
+                    var last = property.WzProperties.Last();
+                    foreach (WzImageProperty p in property.WzProperties)
+                    {
+                        WritePropertyToJson(tw, newDepth, p);
+                        if (!p.Equals(last))
+                        {
+                            tw.Write($",{lineBreak}");
+                        }
+                    }
+                }
+                tw.Write(depth + "}" + lineBreak);
+            }
+            else if (prop is WzShortProperty)
+            {
+                WzShortProperty property = (WzShortProperty)prop;
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {property.Value}");
+            }
+            else if (prop is WzLongProperty)
+            {
+                WzLongProperty property = (WzLongProperty)prop;
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {property.Value}");
+            }
+            else if (prop is WzUOLProperty)
+            {
+                WzUOLProperty property = (WzUOLProperty)prop;
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {property.Value}");
+            }
+            else if (prop is WzVectorProperty)
+            {
+                WzVectorProperty property = (WzVectorProperty)prop;
+                tw.Write($"{depth}\"{XmlUtil.SanitizeText(property.Name)}\":{{" +
+                    $"\"x\": {property.X.Value}, " +
+                    $"\"y\": {property.Y.Value}" +
+                    $"}}{lineBreak}");
+            }
+            else if (prop is WzFloatProperty)
+            {
+                WzFloatProperty property = (WzFloatProperty)prop;
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {property.Value * 1.0}");
+            }
+            else if (prop is WzConvexProperty)
+            {
+                tw.Write($"{depth}\"{XmlUtil.SanitizeText(prop.Name)}\":[");
+                WzConvexProperty property = (WzConvexProperty)prop;
+                string newDepth = depth + indent;
+                if (property.WzProperties.Count() > 0)
+                {
+                    var last = property.WzProperties.Last();
+                    foreach (WzImageProperty p in property.WzProperties)
+                    {
+                        WritePropertyToJson(tw, newDepth, p);
+                        if (!p.Equals(last))
+                        {
+                            tw.Write($",{lineBreak}");
+                        }
+                    }
+                }
+                tw.Write(depth + "]" + lineBreak);
             }
         }
     }
@@ -414,6 +585,70 @@ namespace MapleLib.WzLib.Serialization
             }
             else if (currObj is WzUOLProperty)
                 ExportRecursion(((WzUOLProperty)currObj).LinkValue, outPath);
+        }
+    }
+
+    public class WzJsonSerializer : IWzJsonSerializer, IWzImageSerializer
+    {
+        public WzJsonSerializer(int indentation, LineBreak lineBreakType, bool exportbase64)
+            : base(indentation, lineBreakType)
+        { ExportBase64Data = exportbase64; }
+
+        private string pretty(string data)
+        {
+            return JsonConvert.SerializeObject(JsonConvert.DeserializeObject(data), Newtonsoft.Json.Formatting.Indented);
+        }
+
+        private void exportJsonInternal(WzImage img, string path)
+        {
+            bool parsed = img.Parsed || img.Changed;
+            if (!parsed) img.ParseImage();
+            curr++;
+            TextWriter tw = new StreamWriter(path);
+            tw.Write($"{{\"name\":\"{XmlUtil.SanitizeText(img.Name)}\",{lineBreak}" +
+                $"\"payload\":{{{lineBreak}");
+            var last = img.WzProperties.Last();
+            foreach (WzImageProperty p in img.WzProperties)
+            {
+                WritePropertyToJson(tw, indent, p);
+                if (!p.Equals(last))
+                {
+                    tw.Write($",{lineBreak}");
+                }
+            }
+            tw.Write("}}" + lineBreak);
+            tw.Close();
+            if (!parsed) img.UnparseImage();
+            //File.WriteAllText(path, pretty(File.ReadAllText(path)));
+
+        }
+
+        private void exportDirJsonInternal(WzDirectory dir, string path)
+        {
+            if (!Directory.Exists(path)) createDirSafe(ref path);
+            if (path.Substring(path.Length - 1) != @"\") path += @"\";
+            foreach (WzDirectory subdir in dir.WzDirectories)
+                exportDirJsonInternal(subdir, path + subdir.name + @"\");
+            foreach (WzImage subimg in dir.WzImages)
+                exportJsonInternal(subimg, path + subimg.Name + ".json");
+        }
+
+        public void SerializeImage(WzImage img, string path)
+        {
+            total = 1; curr = 0;
+            if (Path.GetExtension(path) != ".xml") path += ".xml";
+            exportJsonInternal(img, path);
+        }
+
+        public void SerializeDirectory(WzDirectory dir, string path)
+        {
+            total = dir.CountImages(); curr = 0;
+            exportDirJsonInternal(dir, path);
+        }
+
+        public void SerializeFile(WzFile file, string path)
+        {
+            SerializeDirectory(file.WzDirectory, path);
         }
     }
 

--- a/WzLib/WzSerializer.cs
+++ b/WzLib/WzSerializer.cs
@@ -25,8 +25,6 @@ using System.Drawing.Imaging;
 using System.Globalization;
 using System.Xml;
 using System.Drawing;
-using System.Threading;
-using System.CodeDom;
 using Newtonsoft.Json;
 
 namespace MapleLib.WzLib.Serialization
@@ -210,7 +208,7 @@ namespace MapleLib.WzLib.Serialization
         }
 
         // TODO: this is not deserializable due to missing type information
-        protected void WritePropertyToJson(TextWriter tw, WzImageProperty prop, bool isArray=false)
+        protected void WritePropertyToJson(TextWriter tw, WzImageProperty prop, bool isArray = false)
         {
             tw.Write("\n");
             if (prop is WzCanvasProperty)
@@ -295,14 +293,15 @@ namespace MapleLib.WzLib.Serialization
                 }
                 // This has the same problem as the convex property
                 bool propertyIsArray = property.WzProperties.TrueForAll(x => { int num; return int.TryParse(x.Name, out num); });
-                tw.Write(propertyIsArray ? "[": "{");
+                tw.Write(propertyIsArray ? "[" : "{");
                 if (property.WzProperties.Count() > 0)
                 {
                     var last = property.WzProperties.Last();
                     foreach (WzImageProperty p in property.WzProperties)
                     {
                         bool isObject = p is WzConvexProperty || p is WzSubProperty || p is WzSoundProperty || p is WzCanvasProperty || p is WzVectorProperty;
-                        if (propertyIsArray) {
+                        if (propertyIsArray)
+                        {
                             tw.Write($"{{\"index\":{p.Name}, \"item\":");
                             tw.Write(!isObject ? "{" : "");
                         }
@@ -611,7 +610,7 @@ namespace MapleLib.WzLib.Serialization
 
     public class WzJsonSerializer : IWzJsonSerializer, IWzImageSerializer
     {
-        public WzJsonSerializer(bool exportbase64): base()
+        public WzJsonSerializer(bool exportbase64) : base()
         { ExportBase64Data = exportbase64; }
 
         private string pretty(string data)

--- a/WzLib/WzSerializer.cs
+++ b/WzLib/WzSerializer.cs
@@ -284,8 +284,7 @@ namespace MapleLib.WzLib.Serialization
             else if (prop is WzStringProperty)
             {
                 WzStringProperty property = (WzStringProperty)prop;
-                string str = XmlUtil.SanitizeText(property.Value);
-                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": \"{str}\"");
+                tw.Write($"\"{XmlUtil.SanitizeText(property.Name)}\": {JsonConvert.ToString(property.Value)}");
             }
             else if (prop is WzSubProperty)
             {

--- a/WzLib/WzSerializer.cs
+++ b/WzLib/WzSerializer.cs
@@ -633,7 +633,7 @@ namespace MapleLib.WzLib.Serialization
             tw.Write("}}");
             tw.Close();
             if (!parsed) img.UnparseImage();
-            File.WriteAllText(path, pretty(File.ReadAllText(path)));
+            File.WriteAllText(path, pretty(File.ReadAllText(path)), Encoding.GetEncoding("ISO-8859-1"));
 
         }
 

--- a/WzLib/WzSerializer.cs
+++ b/WzLib/WzSerializer.cs
@@ -302,9 +302,16 @@ namespace MapleLib.WzLib.Serialization
                     foreach (WzImageProperty p in property.WzProperties)
                     {
                         bool isObject = p is WzConvexProperty || p is WzSubProperty || p is WzSoundProperty || p is WzCanvasProperty || p is WzVectorProperty;
-                        tw.Write(!isObject && propertyIsArray ? "{" : "");
+                        if (propertyIsArray) {
+                            tw.Write($"{{\"index\":{p.Name}, \"item\":");
+                            tw.Write(!isObject ? "{" : "");
+                        }
                         WritePropertyToJson(tw, p, propertyIsArray);
-                        tw.Write(!isObject && propertyIsArray ? "}" : "");
+                        if (propertyIsArray)
+                        {
+                            tw.Write(!isObject ? "}" : "");
+                            tw.Write("}");
+                        }
                         if (!p.Equals(last))
                         {
                             tw.Write(",");

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NAudio" version="1.10.0" targetFramework="net451" />
+</packages>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NAudio" version="1.10.0" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This adds a `WzJsonSerializer` that formats data in a more direct structure than the existing `WzClassicXmlSerializer`. It is possible to traverse the document tree by document names without having to iterate over every element in the subtree. 

This is used in https://github.com/geospiza-fortis/wzutil for dumping wz to json for analysis. 